### PR TITLE
Add /update endpoint for delivering app updates

### DIFF
--- a/app/routes/repo.py
+++ b/app/routes/repo.py
@@ -75,6 +75,14 @@ def repo_install():
 
     return get_files(library, required_param('apps').split(","))
 
+@repo_routes.route("/update")
+def repo_update():
+    library = get_library(repo(), ref())
+    if library.has_errors():
+        return handle_error(library)
+
+    return get_files(library, required_param('apps').split(","), allow_missing=True)
+
 @repo_routes.route("/bootstrap")
 def repo_bootstrap():
     library = get_library("emfcamp/Mk4-Apps", ref())
@@ -92,11 +100,14 @@ def repo_flash():
 
     return get_files(library, ["bootstrap"])
 
-def get_files(library, apps):
+def get_files(library, apps, allow_missing=False):
     files = {}
     for app_name in apps + ["boot.py"]:
         if app_name not in library.resources:
-            return jsonify({'error': 'app %s not found in library' % app_name}), 404
+            if allow_missing:
+                continue
+            else:
+                return jsonify({'error': 'app %s not found in library' % app_name}), 404
 
         app = library.resources[app_name]
         for file, hashcode in app['files'].items():

--- a/tst/integration/test_http.py
+++ b/tst/integration/test_http.py
@@ -50,6 +50,10 @@ class IntegrationTestHttp(FlaskTestCase):
         data = self.get_json("/install?repo=%s&ref=%s&apps=launcher,app_library" % (self.url, success_commit))
         self.assertDictEqual(data, {'app_library/main.py': 'f57620a4d1', 'boot.py': 'ff8bc259a2', 'launcher/main.py': '2b1477ee36', 'lib/buttons.py': '3fc83d019a', 'lib/dialogs.py': '149678101a', 'lib/wifi.py': 'abe69b0fb1'})
 
+    def test_update(self):
+        data = self.get_json("/update?repo=%s&ref=%s&apps=launcher,app_library,my_awesome_dev_app" % (self.url, success_commit))
+        self.assertDictEqual(data, {'app_library/main.py': 'f57620a4d1', 'boot.py': 'ff8bc259a2', 'launcher/main.py': '2b1477ee36', 'lib/buttons.py': '3fc83d019a', 'lib/dialogs.py': '149678101a', 'lib/wifi.py': 'abe69b0fb1'})
+
     def test_bootstrap(self):
         data = self.get_json("/bootstrap?repo=%s&ref=%s" % (self.url, success_commit))
         self.assertIn("boot.py", data)


### PR DESCRIPTION
It's just like /install, but doesn't 404 if one of the requested apps
is missing from the repo (as is the case when the badge tries to update
all apps and a custom app is present).

For emfcamp/Mk4-Apps#57.